### PR TITLE
SUS-1238: Fix JS error in SMW tooltips

### DIFF
--- a/res/jquery/jquery.qtip.js
+++ b/res/jquery/jquery.qtip.js
@@ -18,10 +18,7 @@
 // Uses AMD or browser globals to create a jQuery plugin.
 (function( factory ) {
 	"use strict";
-	if(typeof define === 'function' && define.amd) {
-		define(['jquery'], factory);
-	}
-	else if(jQuery && !jQuery.fn.qtip) {
+	if(jQuery && !jQuery.fn.qtip) {
 		factory(jQuery);
 	}
 }


### PR DESCRIPTION
jquery.qtip module autodetects AMD but it can't use Wikia's AMD. Let's disable AMD check to ensure qtip function is properly exported to jQuery global

ticket: https://wikia-inc.atlassian.net/browse/SUS-1238