### PR TITLE
SUS-2119: Backport #2460 from SMW upstream

### DIFF
--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -42,8 +42,7 @@ class ArticleDelete {
 				$this->doDelete( $this->wikiPage->getTitle() );
 			} );
 
-		$deferredCallableUpdate->setOrigin( __METHOD__ );
-		$deferredCallableUpdate->pushUpdate();
+		$deferredCallableUpdate->pushToDeferredUpdateList();
 
 		return true;
 	}

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -5,6 +5,10 @@ namespace SMW\MediaWiki\Hooks;
 use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
 use SMW\EventHandler;
+use SMW\SemanticData;
+use SMW\MediaWiki\Jobs\UpdateDispatcherJob;
+use Title;
+use WikiPage;
 
 /**
  * @see https://www.mediawiki.org/wiki/Manual:Hooks/ArticleDelete
@@ -19,74 +23,79 @@ use SMW\EventHandler;
 class ArticleDelete {
 
 	/**
-	 * @var Wikipage
+	 * @var WikiPage $wikiPage
 	 */
 	private $wikiPage = null;
 
 	/**
 	 * @since  2.0
 	 *
-	 * @param Wikipage $wikiPage
+	 * @param WikiPage $wikiPage
 	 */
 	public function __construct( &$wikiPage, &$user, &$reason, &$error ) {
 		$this->wikiPage = $wikiPage;
 	}
 
-	/**
-	 * @since 2.0
-	 *
-	 * @return true
-	 */
 	public function process() {
+		$deferredCallableUpdate =
+			ApplicationFactory::getInstance()->newDeferredCallableUpdate( function () {
+				$this->doDelete( $this->wikiPage->getTitle() );
+			} );
 
-		$applicationFactory = ApplicationFactory::getInstance();
-		$eventHandler = EventHandler::getInstance();
-
-		$title = $this->wikiPage->getTitle();
-		$store = $applicationFactory->getStore();
-
-		$semanticDataSerializer = $applicationFactory->newSerializerFactory()->newSemanticDataSerializer();
-		$jobFactory = $applicationFactory->newJobFactory();
-
-		$deferredCallableUpdate = $applicationFactory->newDeferredCallableUpdate( function() use( $store, $title, $semanticDataSerializer, $jobFactory, $eventHandler ) {
-
-			$subject = DIWikiPage::newFromTitle( $title );
-			wfDebugLog( 'smw', 'DeferredCallableUpdate on delete for ' . $subject->getHash() );
-
-			$parameters['semanticData'] = $semanticDataSerializer->serialize(
-				$store->getSemanticData( $subject )
-			);
-
-			$jobFactory->newUpdateDispatcherJob( $title, $parameters )->insert();
-
-			// Do we want this?
-			/*
-			$properties = $store->getInProperties( $subject );
-			$jobList = array();
-
-			foreach ( $properties as $property ) {
-				$propertySubjects = $store->getPropertySubjects( $property, $subject );
-				foreach ( $propertySubjects as $sub ) {
-					$jobList[$sub->getHash()] = true;
-				}
-			}
-
-			$jobFactory->newUpdateDispatcherJob( $title, array( 'job-list' => $jobList ) )->insert();
-			*/
-			$store->deleteSubject( $title );
-
-			$dispatchContext = $eventHandler->newDispatchContext();
-			$dispatchContext->set( 'title', $title );
-
-			$eventHandler->getEventDispatcher()->dispatch(
-				'cached.propertyvalues.prefetcher.reset',
-				$dispatchContext
-			);
-		} );
-
-		$deferredCallableUpdate->pushToDeferredUpdateList();
+		$deferredCallableUpdate->setOrigin( __METHOD__ );
+		$deferredCallableUpdate->pushUpdate();
 
 		return true;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Title $title
+	 */
+	public function doDelete( Title $title ) {
+
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $applicationFactory->getStore();
+		$subject = DIWikiPage::newFromTitle( $title );
+
+		$semanticDataSerializer =
+			$applicationFactory->newSerializerFactory()->newSemanticDataSerializer();
+		$jobFactory = $applicationFactory->newJobFactory();
+
+		// Instead of Store::getSemanticData, construct the SemanticData by
+		// attaching only the incoming properties indicating which entities
+		// carry an actual reference to this subject
+		$semanticData = new SemanticData( $subject );
+
+		$properties = $store->getInProperties( $subject );
+
+		foreach ( $properties as $property ) {
+			// Avoid doing $propertySubjects = $store->getPropertySubjects( $property, $subject );
+			// as it may produce a too large pool of entities and ultimately
+			// block the delete transaction
+			// Use the subject as dataItem with the UpdateDispatcherJob because
+			// Store::getAllPropertySubjects is only scanning the property
+			$semanticData->addPropertyObjectValue( $property, $subject );
+		}
+
+		$parameters['semanticData'] = $semanticDataSerializer->serialize( $semanticData );
+
+		// Restricted to the available SemanticData
+		$parameters[UpdateDispatcherJob::RESTRICTED_DISPATCH_POOL] = true;
+
+		$jobFactory->newUpdateDispatcherJob( $title, $parameters )->insert();
+
+		$store->deleteSubject( $title );
+
+		$eventHandler = EventHandler::getInstance();
+		$dispatchContext = $eventHandler->newDispatchContext();
+
+		$dispatchContext->set( 'title', $title );
+		$dispatchContext->set( 'context', 'ArticleDelete' );
+
+		$eventHandler->getEventDispatcher()->dispatch( 'cached.prefetcher.reset', $dispatchContext );
 	}
 
 }

--- a/src/MediaWiki/Jobs/UpdateDispatcherJob.php
+++ b/src/MediaWiki/Jobs/UpdateDispatcherJob.php
@@ -19,6 +19,11 @@ use Title;
 class UpdateDispatcherJob extends JobBase {
 
 	/**
+	 * Restrict dispatch process on available pool of data
+	 */
+	const RESTRICTED_DISPATCH_POOL = 'restricted.disp.pool';
+
+	/**
 	 * Size of chunks used when invoking the secondary dispatch run
 	 */
 	const CHUNK_SIZE = 500;
@@ -100,14 +105,17 @@ class UpdateDispatcherJob extends JobBase {
 	}
 
 	private function dispatchUpdateForSubject( DIWikiPage $subject ) {
+		if ( $this->getParameter( self::RESTRICTED_DISPATCH_POOL ) !== true ) {
 
-		$this->addUpdateJobsForProperties(
-			$this->store->getProperties( $subject )
-		);
+			$this->addUpdateJobsForProperties(
+				$this->store->getProperties( $subject )
+			);
 
-		$this->addUpdateJobsForProperties(
-			$this->store->getInProperties( $subject )
-		);
+			$this->addUpdateJobsForProperties(
+				$this->store->getInProperties( $subject )
+			);
+
+		}
 
 		$this->addUpdateJobsFromDeserializedSemanticData();
 	}


### PR DESCRIPTION
ticket: https://wikia-inc.atlassian.net/browse/SUS-2119

Backporting an upstream fix to reduce the number of background tasks spawned on article delete by restricting them to articles that contain a known reference to the article that was deleted, per discussion in #2453.