### PR TITLE
PLATFORM-5337 | Allow to prevent consecutive updates for SMW Database

### DIFF
--- a/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
+++ b/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
@@ -56,6 +56,18 @@ class ExtensionSchemaUpdates {
 	 */
 	public function process() {
 
+		/**
+		 * Fandom change - begin
+		 * Allow to prevent updates if not necessary
+		 *
+		 * PLATFORM-5337
+		 * @author ttomalak
+		 */
+		if ( !\Hooks::run('SMW::Setup::BeforeUpdate') ) {
+			return true;
+		}
+		/** Fandom change - end */
+
 		$verbose = true;
 
 		$options = new Options(


### PR DESCRIPTION
## Description
Currently SMWStore::setupStore is run on every `update.php` or Database update run. Unfortunately `OPTIMIZE` which is run on those update can be very long for bigger wikis and cause big replication lag spike. We can add special hook which will check before update if we wanna run those updates.

## Who might be interested?
@Wikia/core-platform-team 