### PR TITLE
CATS-1366 | Backport patches to use replica DBs

### DIFF
--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -10,7 +10,6 @@ use SMW\Parser\InTextAnnotationParser;
 use Title;
 use Psr\Log\LoggerAwareTrait;
 use SMW\Utils\HmacSerializer;
-use SMW\MediaWiki\RevisionGuard;
 
 /**
  * Factbox output caching
@@ -191,7 +190,7 @@ class CachedFactbox {
 		$outputPage->addModules( Factbox::getModules() );
 		$title = $outputPage->getTitle();
 
-		$rev_id = $this->findRevId( $title, $request );
+		$rev_id = $outputPage->getRevisionId();
 		$lang = $context->getLanguage()->getCode();
 		$content = '';
 
@@ -287,9 +286,7 @@ class CachedFactbox {
 			$context = $outputPage->getContext();
 			$lang = $context->getLanguage()->getCode();
 
-			$rev_id = $this->findRevId(
-				$title, $context->getRequest()
-			);
+			$rev_id = $outputPage->getRevisionId();
 
 			$sub = $this->makeSubCacheKey( $rev_id, $lang, $this->featureSet );
 
@@ -308,23 +305,6 @@ class CachedFactbox {
 		}
 
 		return $text;
-	}
-
-	/**
-	 * Return a revisionId either from the WebRequest object (display an old
-	 * revision or permalink etc.) or from the title object
-	 */
-	private function findRevId( Title $title, $request ) {
-
-		if ( $request->getInt( 'diff' ) > 0 ) {
-			return $request->getInt( 'diff' );
-		}
-
-		if ( $request->getInt( 'oldid' ) > 0 ) {
-			return $request->getInt( 'oldid' );
-		}
-
-		return RevisionGuard::getLatestRevID( $title );
 	}
 
 	/**

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use SMW\ApplicationFactory;
 use SMW\Connection\ConnRef;
 use UnexpectedValueException;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * This adapter class covers MW DB specific operations. Changes to the
@@ -308,6 +309,8 @@ class Database {
 	}
 
 	/**
+	 * Execute a given SQL query on the primary DB.
+	 *
 	 * @see DatabaseBase::query
 	 *
 	 * @since 1.9
@@ -320,9 +323,48 @@ class Database {
 	 * @throws RuntimeException
 	 */
 	public function query( $sql, $fname = __METHOD__, $ignoreException = false ) {
+		$results = $this->executeQuery(
+			$this->connRef->getConnection( 'write' ),
+			$sql,
+			$fname,
+			$ignoreException
+		);
 
-		$connection = $this->connRef->getConnection( 'write' );
+		return $results;
+	}
 
+	/**
+	 * Execute a given SQL query on a read-only replica DB.
+	 *
+	 * @see IDatabase::query()
+	 * @since 4.0.0
+	 *
+	 * @param Query|string $sql
+	 * @param string $fname
+	 * @param false $ignoreException
+	 * @return bool|\Wikimedia\Rdbms\IResultWrapper
+	 * @throws Exception
+	 */
+	public function readQuery( $sql, $fname = __METHOD__, $ignoreException = false ) {
+		return $this->executeQuery(
+			$this->connRef->getConnection( 'read' ),
+			$sql,
+			$fname,
+			$ignoreException
+		);
+	}
+
+	/**
+	 * Execute a SQL query using the given DB connection handle.
+	 *
+	 * @param IDatabase $connection
+	 * @param Query|string $sql
+	 * @param $fname
+	 * @param $ignoreException
+	 * @return bool|\Wikimedia\Rdbms\IResultWrapper
+	 * @throws Exception
+	 */
+	private function executeQuery( IDatabase $connection, $sql, $fname, $ignoreException ) {
 		if ( $sql instanceof Query ) {
 			$sql = $sql->build();
 		}

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -520,7 +520,7 @@ class SemanticDataLookup {
 			$caller .= " (for " . $requestOptions->getCaller() . ")";
 		}
 
-		$res = $connection->query(
+		$res = $connection->readQuery(
 			$query,
 			$caller
 		);

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -69,6 +69,9 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider outputDataProvider
 	 */
 	public function testProcessAndRetrieveContent( $parameters, $expected ) {
+		$this->entityCache->expects( $this->any() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
 
 		$this->testEnvironment->addConfiguration(
 			'smwgNamespacesWithSemanticLinks',
@@ -258,6 +261,10 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getContext' )
 			->will( $this->returnValue( new \RequestContext() ) );
 
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'getRevisionId' )
+			->will( $this->returnValue( 10001 ) );
+
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
@@ -302,6 +309,10 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$outputPage->expects( $this->atLeastOnce() )
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
+
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'getRevisionId' )
+			->will( $this->returnValue( 9001 ) );
 
 		$context = new \RequestContext( );
 		$context->setRequest( new \FauxRequest( [ 'oldid' => 9001 ], true ) );
@@ -398,6 +409,10 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$outputPage->expects( $this->atLeastOnce() )
 			->method( 'getContext' )
 			->will( $this->returnValue( new \RequestContext() ) );
+
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'getRevisionId' )
+			->will( $this->returnValue( 10004 ) );
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -72,7 +72,6 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider outputDataProvider
 	 */
 	public function testProcess( $parameters, $expected ) {
-
 		$this->namespaceExaminer->expects( $this->any() )
 			->method( 'isSemanticEnabled' )
 			->will( $this->returnValue( $parameters['smwgNamespacesWithSemanticLinks'] ) );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -68,7 +68,6 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider outputDataProvider
 	 */
 	public function testperformUpdateFactboxPresenterIntegration( $parameters, $expected ) {
-
 		$data = '';
 
 		$instance = new SkinAfterContent( $parameters['skin'] );

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
@@ -211,7 +211,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( 'Foo' ) );
 
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )
@@ -275,7 +275,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )
@@ -336,7 +336,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )
@@ -388,7 +388,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )
@@ -498,7 +498,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )
@@ -570,6 +570,10 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->connection->expects( $this->atLeastOnce() )
 			->method( 'query' )
+			->will( $this->returnValue( [ $row ] ) );
+
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )


### PR DESCRIPTION
Backport https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/5002 and https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4952 for release.