### PR TITLE
Use readQuery method in PropertySubjectsLookup

### DIFF
--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -327,7 +327,7 @@ class PropertySubjectsLookup {
 			$caller .= " (for " . $requestOptions->getCaller() . ")";
 		}
 
-		$res = $connection->query(
+		$res = $connection->readQuery(
 			$query,
 			$caller
 		);


### PR DESCRIPTION
PropertySubjectsLookup doesn't make any writes, so instead of using "write" connection it should query it through "read". This doesn't appear in the transaction-profiler as "query" method is silenced.