### PR TITLE
fix: make Query::execute use alway read connection

### DIFF
--- a/src/MediaWiki/Connection/Query.php
+++ b/src/MediaWiki/Connection/Query.php
@@ -363,7 +363,7 @@ class Query {
 	 * @return iterable
 	 */
 	public function execute( $fname ) {
-		return $this->connection->query( $this, $fname );
+		return $this->connection->readQuery( $this, $fname );
 	}
 
 	private function sql() {


### PR DESCRIPTION
`Query` class should use only 'read' connections to fetch data.