### PR TITLE
UGC-6410 Change the performer for search import script

### DIFF
--- a/data/import/smw.search.json
+++ b/data/import/smw.search.json
@@ -4,7 +4,7 @@
 		{
 			"page": "Profile:Facetedsearch default profile",
 			"namespace": "SMW_NS_SCHEMA",
-			"import_performer": "SemanticMediaWikiImporter",
+			"import_performer": "FANDOMBot",
 			"contents": {
 				"importFrom": "/search/facetedsearch.defaultprofile.json"
 			},


### PR DESCRIPTION
`runImport.php` fails as it tries to create a new MW "system user" which would never succeed in our setup. Let's use an existing bot account for this action to prevent the logic from creating a new user instead.

Related: https://github.com/Wikia/unified-platform/pull/21117